### PR TITLE
Add /img directory to .nowignore

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,1 +1,2 @@
 node_modules
+img


### PR DESCRIPTION
Looks like the images stored here are used only for the GitHub repository. In that case, you can do without deploying them to now.